### PR TITLE
Bum Thorntail to 2.5.0 and rename OT package

### DIFF
--- a/Chapter04-jwtpropagation/src/main/java/io/pckt/ot/rest/InjectionExampleEndpoint.java
+++ b/Chapter04-jwtpropagation/src/main/java/io/pckt/ot/rest/InjectionExampleEndpoint.java
@@ -1,4 +1,4 @@
-package io.pckt.jwt.rest;
+package io.pckt.ot.rest;
 
 import java.util.Set;
 

--- a/Chapter04-jwtpropagation/src/main/java/io/pckt/ot/rest/JaxrsApplication.java
+++ b/Chapter04-jwtpropagation/src/main/java/io/pckt/ot/rest/JaxrsApplication.java
@@ -1,4 +1,4 @@
-package io.pckt.jwt.rest;
+package io.pckt.ot.rest;
 
 
 import javax.ws.rs.ApplicationPath;

--- a/Chapter04-jwtpropagation/src/main/java/io/pckt/ot/rest/SecureEndpoint.java
+++ b/Chapter04-jwtpropagation/src/main/java/io/pckt/ot/rest/SecureEndpoint.java
@@ -1,4 +1,4 @@
-package io.pckt.jwt.rest;
+package io.pckt.ot.rest;
 
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;

--- a/Chapter05-opentracing/pom.xml
+++ b/Chapter05-opentracing/pom.xml
@@ -46,18 +46,7 @@
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>microprofile-opentracing</artifactId>
-         <!-- TODO using snapshot because 1.4.0.Final has a bug and does not trace MP Rest Client -->
-        <version>2.4.1.Final-SNAPSHOT</version>
       </dependency>
     </dependencies>
-
-    <repositories>
-      <repository>
-        <id>snapshots-repo</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        <releases><enabled>false</enabled></releases>
-        <snapshots><enabled>true</enabled></snapshots>
-      </repository>
-    </repositories>
 </project>
 

--- a/Chapter05-opentracing/src/main/java/io/pckt/ot/rest/ConversationService.java
+++ b/Chapter05-opentracing/src/main/java/io/pckt/ot/rest/ConversationService.java
@@ -1,4 +1,4 @@
-package io.pckt.jwt.rest;
+package io.pckt.ot.rest;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;

--- a/Chapter05-opentracing/src/main/java/io/pckt/ot/rest/Endpoint.java
+++ b/Chapter05-opentracing/src/main/java/io/pckt/ot/rest/Endpoint.java
@@ -1,4 +1,4 @@
-package io.pckt.jwt.rest;
+package io.pckt.ot.rest;
 
 import io.opentracing.Tracer;
 import javax.inject.Inject;

--- a/Chapter05-opentracing/src/main/java/io/pckt/ot/rest/GreetingService.java
+++ b/Chapter05-opentracing/src/main/java/io/pckt/ot/rest/GreetingService.java
@@ -1,4 +1,4 @@
-package io.pckt.jwt.rest;
+package io.pckt.ot.rest;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/Chapter05-opentracing/src/main/java/io/pckt/ot/rest/JaxrsApplication.java
+++ b/Chapter05-opentracing/src/main/java/io/pckt/ot/rest/JaxrsApplication.java
@@ -1,4 +1,4 @@
-package io.pckt.jwt.rest;
+package io.pckt.ot.rest;
 
 
 import javax.ws.rs.ApplicationPath;

--- a/Chapter05-opentracing/src/main/resources/META-INF/microprofile-config.properties
+++ b/Chapter05-opentracing/src/main/resources/META-INF/microprofile-config.properties
@@ -1,1 +1,1 @@
-io.pckt.jwt.rest.GreetingService/mp-rest/url=http://localhost:8080
+io.pckt.ot.rest.GreetingService/mp-rest/url=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Hands-On Enterprise Java Microservices with Eclipse MicroProfile, published by P
 This repo contains code samples for the Microprofile Packt book. Each directory in this repo corresponds to a chapter in the book. Also, some directories have sub-directories that map to sub-chapters in the book.
 
 ## Thorntail
-The book code makes use of the [Thorntail](https://thorntail.io/) MicroProfile runtime, version 2.4.0.Final.
+The book code makes use of the [Thorntail](https://thorntail.io/) MicroProfile runtime, version 2.5.0.Final.
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </scm>
 
     <properties>
-        <thorntail.version>2.4.0.Final</thorntail.version>
+        <thorntail.version>2.5.0.Final</thorntail.version>
         <junit.version>5.4.1</junit.version>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
@pilhuhn @cealsair @starksm64 I would like to bump Thorntail version to 2.5.0 the older version had a bug which was affecting my example. 

Signed-off-by: Pavol Loffay <ploffay@redhat.com>